### PR TITLE
Implemented status API and a 'redirect if closed' method

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,20 +8,47 @@
     </head>
     <body>
         <p>For now you can play with the browser console to examine the jspsych uil utils</p>
-    </body>
     <script>
 
-        let start_screen = {
-            type: 'html-button-response',
-            stimulus: "Press the ok button to continue", 
-            choices: ["OK"],
-            response_ends_trial: true
-        };
+const ACCESS_KEY = "d673bcac-584b-426b-93dc-8dc901a95db6";
+const ACC_ACCESS_KEY = "01d3f980-15de-476a-b5a5-2d60b0fb8aaa";
 
-        jsPsych.init(
-            {
-                timeline:[start_screen]
+
+function testUtils() {
+
+    let server = "acc";
+
+    if (server === "acc") {
+        uil.useAcceptationServer();
+        uil.setAccessKey(ACC_ACCESS_KEY);
+    }
+    else {
+        uil.setAccessKey(ACCESS_KEY);
+    }
+    
+    uil.stopIfExperimentClosed();
+
+    let start_screen = {
+        type: 'html-button-response',
+        stimulus: "Press the ok button to continue", 
+        choices: ["OK"],
+        response_ends_trial: true
+    };
+
+    jsPsych.init(
+        {
+            timeline:[start_screen],
+            on_finish : function() {
+                uil.saveData();
             }
-        )
-    </script>
+        }
+    )
+}
+
+window.addEventListener (
+    'load',
+    testUtils
+);
+        </script>
+    </body>
 </html>

--- a/jspsych-uil-utils.js
+++ b/jspsych-uil-utils.js
@@ -41,7 +41,7 @@ var uil = {};
         'https://web-experiments.lab.hum.uu.nl/index_files/closed/';
 
     const DATA_UPLOAD_ENDPOINT = '/upload/';
-    const DATA_STATUS_ENDPOINT = '/status/';
+    const DATA_METADATA_ENDPOINT = '/metadata/';
 
     const POST = 'POST';
     const GET = 'GET';
@@ -121,7 +121,7 @@ var uil = {};
 
         // As this is an async call, we return a promise. That way we can actually easily do stuff with the result
         return new Promise((resolve, reject) => {
-            xhr.open(GET, server + access_key + DATA_STATUS_ENDPOINT);
+            xhr.open(GET, server + access_key + DATA_METADATA_ENDPOINT);
             xhr.responseType = "json";
 
             xhr.onload = function() {

--- a/jspsych-uil-utils.js
+++ b/jspsych-uil-utils.js
@@ -60,7 +60,7 @@ var uil = {};
 
     let _acc_server = false;
 
-    let _experiment_metadata = undefined;
+    let _datastore_metadata = undefined;
 
     /* ************ private functions ************* */
 
@@ -113,9 +113,9 @@ var uil = {};
      */
     function getExperimentMetadata(access_key, server) {
 
-        if (typeof(_experiment_metadata) !== "undefined")
+        if (typeof(_datastore_metadata) !== "undefined")
             // If we already have the data, return a auto-fulfilling promise
-            return new Promise((resolve, _) => {resolve(_experiment_metadata);});
+            return new Promise((resolve, _) => {resolve(_datastore_metadata);});
 
         let xhr = new XMLHttpRequest();
 
@@ -126,7 +126,7 @@ var uil = {};
 
             xhr.onload = function() {
                 if(xhr.status === 200){
-                    _experiment_metadata = xhr.response;
+                    _datastore_metadata = xhr.response;
                     resolve(xhr.response);
                 }
                 else {


### PR DESCRIPTION
This PR has the following changes:

* Fixed all broken 'undefined' checks. (Typeof returns a string  ``'undefined'``, not ``undefined`` itself)
* New public method: ``setAccessKey``, which can be used to set a default access key to be used for all API calls. 
* New public method: ``useAcceptationServer``, which can be used to set the default to ``true`` for ``acc_server`` parameters 
* New private method: ``getExperimentMetadata``, which retrieves all data from the new status API endpoint
* New public method: ``stopIfExperimentClosed``, which will redirect a user to a generic 'closed' experiment if the metadata claims it is closed. It will also warn a user the experiment is in piloting mode if it is. 

As you can see, I've decided to add methods to set a default access key and server. As the amount of API related methods is bound to grow, I think it's better to set these values once. (Instead of having them everywhere in the code). 
I've kept the old parameter options as an override, but in my opinion we should switch our boilerplates to this new method of providing this data. 

As an added bonus, the ``useAcceptationServer`` method will be easier to spot than a ``, true`` in a method call. (Inspired by Areti accidentally leaving that ``true`` in her code). 

This PR is backwards compatible with the currently deployed version. However, I would like to propose that the next backwards-incompatible version will move all API communication to a seperate sub-library (like randomisation is) and drop support for the parameters ``access_key`` and ``acc_server`` on relevant methods. 
I think this will improve maintainability and readability, as the API code is starting to dominate the main file. I'd rather see the main file used for smaller, standalone, functions. 