### PR TITLE
Allow extracting dataservers subject_id

### DIFF
--- a/jspsych-uil-session.js
+++ b/jspsych-uil-session.js
@@ -152,7 +152,7 @@ else
          *
          * @returns the subject_id from the data store.
          */
-        context.subject_id = function() {
+        context.subjectId = function() {
             if (session_id === null) {
                 throw new Error('No active session')
             }

--- a/jspsych-uil-session.js
+++ b/jspsych-uil-session.js
@@ -104,6 +104,8 @@ else
         }
 
         var session_id = null;
+        var subject_id = null;
+
         var api = new API(uil.resolveServer());
 
         /**
@@ -127,6 +129,7 @@ else
         context.start = function(access_key, callback) {
             api.sessionStart(access_key).then((data) => {
                 session_id = data.uuid;
+                subject_id = data.subject_id;
                 callback(data.group_name);
             });
         };
@@ -143,5 +146,18 @@ else
 
             api.sessionUpload(access_key, session_id, data);
         };
+
+        /**
+         * Obtain an subject_id from the the dataserver
+         *
+         * @returns the subject_id from the data store.
+         */
+        context.subject_id = function() {
+            if (session_id === null) {
+                throw new Error('No active session')
+            }
+
+            return subject_id;
+        }
     })(uil.session);
 }


### PR DESCRIPTION
This is a little bit of extra work that enables the users of our jspsych-uil-utils to obtain the subject_id from a session. I've tried to add an subject_id to a ParticipantSession in the webexperiments-data store.
You request a session just as we did before. When the server responds the subject_id is cached privately inside of `uil.session`. And I've added an accessor function that the client can call to retrieve it. This should work in unison with the same pull request on the web experiments data store 