### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ prime boiler plate :
         <link href="https://web-experiments.lab.hum.uu.nl/jspsych/6.1.0/css/jspsych.css" rel="stylesheet" type="text/css"/>
 
         <!-- Uil OTS libraries -->
-        <script src="https://web-experiments.lab.hum.uu.nl/jspsych-uil-utils/jspsych-uil-utils.js"></script>
+        <script src="https://web-experiments.lab.hum.uu.nl/jspsych-uil-utils/0.3/jspsych-uil-utils-import.js"></script>
 
         <!-- Uil OTS scripts -->
         <script src="stimuli.js"></script>

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ prime boiler plate :
         <link href="https://web-experiments.lab.hum.uu.nl/jspsych/6.1.0/css/jspsych.css" rel="stylesheet" type="text/css"/>
 
         <!-- Uil OTS libraries -->
-        <script src="https://web-experiments.lab.hum.uu.nl/jspsych-uil-utils/0.3/jspsych-uil-utils-import.js"></script>
+        <type="module" script src="https://web-experiments.lab.hum.uu.nl/jspsych-uil-utils/0.3/jspsych-uil-utils-import.js"></script>
 
         <!-- Uil OTS scripts -->
         <script src="stimuli.js"></script>


### PR DESCRIPTION
Newer experiments should import the uil utils module via jspsych-uil-utils-import.js. This will put the uil module at the window, making it global. This allows to import it without being a module it self, keeping "expert" (such as modules) outside the scope of clients.