### PR TITLE
display the the experiment's JSON data in a new window

### DIFF
--- a/jspsych-uil-utils.js
+++ b/jspsych-uil-utils.js
@@ -405,12 +405,13 @@ function saveJson (json, access_key, acc_server = undefined) {
     else {
         // show the data in prettyfied format
         json = JSON.stringify(JSON.parse(json), null, 4);
-        // clear the body
-        document.body.innerHTML= '';
         // Add preformatted json content.
         let pre_element = document.createElement("pre");
         pre_element.innerText = json;
-        document.body.append(pre_element);
+
+        let content = `<!doctype html><html><body><h1>Experiment Data (debug version)</h1>${pre_element.outerHTML}</body></html>`;
+        let url = URL.createObjectURL(new Blob([content], {type: 'text/html;charset=utf-8'}));
+        window.open(url);
     }
 }
 

--- a/spec/utils.spec.mjs
+++ b/spec/utils.spec.mjs
@@ -63,12 +63,15 @@ describe('saveJson', () => {
         expect(request.params).toBe(JSON.stringify(data));
     });
 
-    it('should display json when offline', () => {
-        let mockBody = document.createElement('body');
-        spyOnProperty(document, 'body').and.returnValue(mockBody);
+    it('should display json when offline', async () => {
+        let open = spyOn(window, 'open');
+
         utils.saveJson(JSON.stringify(data), key);
 
-        let parsed = JSON.parse(mockBody.innerText);
+        expect(open).toHaveBeenCalled();
+        let blob = await fetch(open.calls.first().args[0], {headers: {'content-type': 'text/html;charset=utf-8'}});
+        let dom = new DOMParser().parseFromString(await blob.text(), 'text/html');
+        let parsed = JSON.parse(dom.querySelector('pre').innerText);
         expect(parsed).toEqual(data);
     });
 });


### PR DESCRIPTION
Our current solution for showing the experiment's data instead of sending it to the server when running on localhost is very useful, but because it's rewriting the DOM it prevents jsPsych from continuing.
This PR changes the behavior to show the data in a new window. As a bonus, it will also show multiple windows when `saveJSON()` is called multiple times.